### PR TITLE
修复 css,js 生成注释路径的错误

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -9,14 +9,14 @@ module.exports = function (opts) {
         css: function (fileName) {
             return render('css', {
                 loclaUrl: ['..', opts.cssDir, fileName].join('/'),
-                cdnUrl: [opts.cdnUrl, opts.projectName, opts.cssDir, fileName].join('/')
+                cdnUrl: [opts.cdnUrl, opts.projectName, 'dist', opts.cssDir, fileName].join('/')
             })
         },
 
         js: function (fileName) {
             return render('js', {
                 loclaUrl: ['..', opts.jsDir, fileName].join('/'),
-                cdnUrl: [opts.cdnUrl, opts.projectName, opts.jsDir, fileName].join('/')
+                cdnUrl: [opts.cdnUrl, opts.projectName, 'dist', opts.jsDir, fileName].join('/')
             })
         },
 


### PR DESCRIPTION
目前 tmt-ejs-helper 生成的线上注释如下：

``` html
<!--<link rel="stylesheet" href="http://wximg.gtimg.com/tmt/workflow-next/css/style-templateA.css"/>-->
```

正确应该如下：

``` html
<!--<link rel="stylesheet" href="http://wximg.gtimg.com/tmt/workflow-next/dist/css/style-templateA.css"/>-->
```
